### PR TITLE
Renovate: Force npm and composer versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,12 +7,11 @@
   ],
   "versioning": "semver",
   "dependencyDashboard": true,
-  "lockFileMaintenance": {
-    "enabled": true
-  },
-  "composerIgnorePlatformReqs": [
-    "ext-*",
-    "lib-*"
-  ],
-  "rangeStrategy": "update-lockfile"
+  "lockFileMaintenance": { "enabled": true },
+  "composerIgnorePlatformReqs": ["ext-*", "lib-*"],
+  "rangeStrategy": "update-lockfile",
+  "constraints": {
+    "composer": "> 2.3",
+    "npm": "> 8.0"
+  }
 }


### PR DESCRIPTION
This enforces renovate to use the version 2 schemas of package-lock.json and composer.lock